### PR TITLE
Add cpio dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
     bc binfmt-support bzip2 fakeroot gcc gcc-arm-linux-gnueabihf \
     git gnupg make parted qemu-user-static wget xz-utils zip \
-    debootstrap sudo dirmngr bison flex libssl-dev kmod udev
+    debootstrap sudo dirmngr bison flex libssl-dev kmod udev cpio
 
 # install golang
 ARG GOLANG_TARBALL=go1.13.6.linux-amd64.tar.gz


### PR DESCRIPTION
This pull requests add the cpio dependency to the list of packages instaled inside the docker environment.

This dependency is required for the build process to succeed.

Without it, the process stops with the following error: ```cpio: command not found.```
```
```