### PR TITLE
Add libpam-systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ debian: check_version usbarmory-${IMG_VERSION}.raw
 	sudo mount -o loop,offset=5242880 -t ext4 usbarmory-${IMG_VERSION}.raw rootfs/
 	sudo update-binfmts --enable qemu-arm
 	sudo qemu-debootstrap \
-		--include=ssh,sudo,ntpdate,fake-hwclock,openssl,vim,nano,cryptsetup,lvm2,locales,less,cpufrequtils,isc-dhcp-server,haveged,rng-tools,whois,iw,wpasupplicant,dbus,apt-transport-https,dirmngr,ca-certificates,u-boot-tools,mmc-utils,gnupg \
+		--include=ssh,sudo,ntpdate,fake-hwclock,openssl,vim,nano,cryptsetup,lvm2,locales,less,cpufrequtils,isc-dhcp-server,haveged,rng-tools,whois,iw,wpasupplicant,dbus,apt-transport-https,dirmngr,ca-certificates,u-boot-tools,mmc-utils,gnupg,libpam-systemd \
 		--arch=armhf buster rootfs http://ftp.debian.org/debian/
 	sudo install -m 755 -o root -g root conf/rc.local rootfs/etc/rc.local
 	sudo install -m 644 -o root -g root conf/sources.list rootfs/etc/apt/sources.list


### PR DESCRIPTION
There is a rather annoying bug when using ssh to the armory. When you reboot or shutdown your ssh connection just hangs. No disconnect or nothing. This is solved by installing libpam-systemd, as this will make ssh receive the shutdown/reboot event and close all connections. For more details see:
https://serverfault.com/questions/706475/ssh-sessions-hang-on-shutdown-reboot